### PR TITLE
Replace sqlite RETURNING with traditional SELECT

### DIFF
--- a/python/main.py
+++ b/python/main.py
@@ -153,7 +153,8 @@ async def add_item(name: str = Form(..., max_length=32), category: str = Form(..
         cur.execute('''SELECT id FROM category WHERE name = (?)''', (category, ))
         category_result = cur.fetchone()
         if (category_result is None):
-            cur.execute('''INSERT INTO category(name) VALUES (?) RETURNING id''', (category, ))
+            cur.execute('''INSERT INTO category(name) VALUES (?)''', (category, ))
+            cur.execute('''SELECT id FROM category WHERE name = (?)''', (category, ))
             category_result = cur.fetchone()
         cur.execute('''INSERT INTO items(name, category_id, image_filename) VALUES (?, ?, ?)''', (name, category_result[0], new_image_name))
         conn.commit()


### PR DESCRIPTION
## What

- Replace the syntax RETURNING in a sqlite query with a traditional SELECT query

Reason: The RETURNING syntax is only supported by SQLite version 3.35.0 (released 2021-03-12) or above. The image we use in docker (python:3.10.4-slim-buster) does not support this version of SQLite.

## CHECKS :warning:

Please make sure you are aware of the following.

- [x] **The changes in this PR doesn't have private information
